### PR TITLE
[Go] annotation and comment highlighting

### DIFF
--- a/Go.sublime-syntax
+++ b/Go.sublime-syntax
@@ -76,7 +76,7 @@ variables:
 
   # Whitespace and general comments on a single line.
   # This should only be used for lookahead, not for capturing / scoping.
-  noise: (?:\s*|{{inline_comment}})*
+  noise: (?:\s|{{inline_comment}})*
 
   char_escape: \\x\h{2}|\\u\h{4}|\\U\h{8}|\\[0-7]{3}|\\.
 
@@ -98,12 +98,8 @@ contexts:
     # an annotation, while assigning ONLY the commend scope to the end of the
     # line. This way, a background color applied to an annotation scope doesn't
     # apply to the infinite blank space on the rest of the line.
-    - match: (//)(go)(:)({{ident}})?
-      captures:
-        1: punctuation.definition.annotation.go
-        2: keyword.annotation.go
-        3: punctuation.accessor.double-colon.go
-        4: variable.annotation.function.go
+    - match: //(?=go:)
+      scope: punctuation.definition.comment.go
       push: [meta-comment, meta-annotation]
     # line comments
     - match: //
@@ -122,8 +118,6 @@ contexts:
     - meta_scope: meta.annotation.go
     - match: $
       pop: true
-    - match: '{{ident}}'
-      scope: variable.annotation.parameter.go
 
   meta-comment:
     - meta_scope: comment.line.go

--- a/Go.sublime-syntax
+++ b/Go.sublime-syntax
@@ -92,33 +92,43 @@ contexts:
 
   # https://golang.org/ref/spec#Comments
   match-comments:
-    - include: match-line-comment
-    - include: match-general-comment
-
-  match-line-comment:
     # Go has special comments in the form of:
     #   //go:some-directive arg0 arg1 ...
     # This regexp captures such a line, carefully scoping it as a comment and
     # an annotation, while assigning ONLY the commend scope to the end of the
     # line. This way, a background color applied to an annotation scope doesn't
     # apply to the infinite blank space on the rest of the line.
-    - match: (//go:.*)\s
-      scope: comment.line.go
+    - match: (//)(go)(:)({{ident}})?
       captures:
-        1: meta.annotation.go
-
-    # Explicitly matching \s also captures end-of-line. This ensures that things
-    # that rely on comment scoping, such as hotkeys, work properly at the end of
-    # the line when typing a new comment.
-    - match: //(?:.|\s)*
-      scope: comment.line.go
-
-  match-general-comment:
+        1: punctuation.definition.annotation.go
+        2: keyword.annotation.go
+        3: punctuation.accessor.double-colon.go
+        4: variable.annotation.function.go
+      push: [meta-comment, meta-annotation]
+    # line comments
+    - match: //
+      scope: punctuation.definition.comment.go
+      push: meta-comment
+    # general comments
     - match: /\*
+      scope: punctuation.definition.comment.begin.go
       push:
         - meta_scope: comment.block.go
         - match: \*/
+          scope: punctuation.definition.comment.end.go
           pop: true
+
+  meta-annotation:
+    - meta_scope: meta.annotation.go
+    - match: $
+      pop: true
+    - match: '{{ident}}'
+      scope: variable.annotation.parameter.go
+
+  meta-comment:
+    - meta_scope: comment.line.go
+    - match: $\n?
+      pop: true
 
   # https://golang.org/ref/spec#Tokens
   match-tokens:

--- a/syntax_test_go.go
+++ b/syntax_test_go.go
@@ -56,23 +56,14 @@ You may have to disable Go-specific linters when working on this file.
 
     //go:
 // ^ - comment - meta - punctuation
-//  ^^ punctuation.definition.annotation.go
+//  ^^ punctuation.definition.comment.go
 //  ^^^^^ comment.line.go meta.annotation.go
-//      ^ punctuation.accessor.double-colon.go
 //       ^ comment.line.go - meta.annotation
 
     //go:generate one two three
 // ^ - comment - meta - punctuation
-//  ^^ punctuation.definition.annotation.go
+//  ^^ punctuation.definition.comment.go
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
-//      ^ punctuation.accessor.double-colon.go
-//       ^^^^^^^^ variable.annotation.function.go
-//               ^ - variable
-//                ^^^ variable.annotation.parameter.go
-//                   ^ - variable
-//                    ^^^ variable.annotation.parameter.go
-//                       ^ - variable
-//                        ^^^^^ variable.annotation.parameter.go
 //                             ^ comment.line.go - meta.annotation.go - variable
 
 

--- a/syntax_test_go.go
+++ b/syntax_test_go.go
@@ -14,25 +14,66 @@ You may have to disable Go-specific linters when working on this file.
 
 // # Comments
 
-    // comment
-//  ^^^^^^^^^^ comment.line.go
+    //
+// ^ - comment - punctuation
+//  ^^ punctuation.definition.comment.go
+//  ^^^ comment.line.go
 
-    /* comment */  // comment
-//  ^^^^^^^^^^^^^ comment.block.go
-//                 ^^^^^^^^^^ comment.line.go
+    // comment // comment
+// ^ - comment - punctuation
+//  ^^ punctuation.definition.comment.go
+//  ^^^^^^^^^^^^^^^^^^^^^^ comment.line.go
+//             ^^ - punctuation
+
+    /* comment // comment */  // comment
+// ^ - comment - punctuation
+//  ^^ punctuation.definition.comment.begin.go
+//  ^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.go
+//             ^^ - punctuation
+//                        ^^ punctuation.definition.comment.end.go
+//                          ^^ - comment - punctuation
+//                            ^^ punctuation.definition.comment.go
+//                            ^^^^^^^^^^^ comment.line.go
 
     /*
+// ^ - comment
 //  ^^^^ comment.block.go
     comment
 //  ^^^^^^^^ comment.block.go
     */
 //  ^^ comment.block.go
+//    ^ - comment
 
     /* * */
+// ^ - comment
 //  ^^^^^^^ comment.block.go
+//         ^ - comment
+
+    //go
+// ^ - comment - punctuation
+//  ^^ punctuation.definition.comment.go
+//  ^^^^^ comment.line.go - meta.annotation
+
+    //go:
+// ^ - comment - meta - punctuation
+//  ^^ punctuation.definition.annotation.go
+//  ^^^^^ comment.line.go meta.annotation.go
+//      ^ punctuation.accessor.double-colon.go
+//       ^ comment.line.go - meta.annotation
 
     //go:generate one two three
+// ^ - comment - meta - punctuation
+//  ^^ punctuation.definition.annotation.go
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.go meta.annotation.go
+//      ^ punctuation.accessor.double-colon.go
+//       ^^^^^^^^ variable.annotation.function.go
+//               ^ - variable
+//                ^^^ variable.annotation.parameter.go
+//                   ^ - variable
+//                    ^^^ variable.annotation.parameter.go
+//                       ^ - variable
+//                        ^^^^^ variable.annotation.parameter.go
+//                             ^ comment.line.go - meta.annotation.go - variable
 
 
 // # Imports


### PR DESCRIPTION
This commit introduces the following changes to the Go language which
are inspired by existing default syntaxes:

1. Add `punctuation` scopes for comment punctuations
2. Add special annotation scopes to enable highlighting preprocessor directives. A directive is scoped as `variable.annotation.function` as it can be interpreted as a function performed at compile time.
3. The annotations and comments use the same `meta-comment` context to avoid duplicated patterns.
4. The comment contexts are merged to one `match-comments` as they
   - belong together
   - are not used separately
   - are mentioned together in the https://golang.org/ref/spec#Comments
   - to decrease the syntax granularity